### PR TITLE
don't append collapse symbol when collapse span is null

### DIFF
--- a/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/FastTextView.java
+++ b/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/FastTextView.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.MotionEvent;
+import android.view.ViewTreeObserver;
 
 /**
  * Simple and Fast TextView.
@@ -132,7 +133,6 @@ public class FastTextView extends FastTextLayoutView {
 
   @Override
   protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-    long start = System.currentTimeMillis();
     int width = MeasureSpec.getSize(widthMeasureSpec);
     boolean exactly = MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY;
     if (!exactly) {
@@ -163,11 +163,6 @@ public class FastTextView extends FastTextLayoutView {
           getMeasuredHeight(getPaddingTop() + getPaddingBottom() + height, heightMeasureSpec));
     } else {
       super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-    }
-
-    long end = System.currentTimeMillis();
-    if (BuildConfig.DEBUG) {
-      Log.d(TAG, "onMeasure cost:" + (end - start));
     }
   }
 

--- a/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
+++ b/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
@@ -117,8 +117,8 @@ public class ReadMoreTextView extends FastTextView {
   protected StaticLayout makeLayout(CharSequence text, int maxWidth, boolean exactly) {
     mWithEllipsisLayout = super.makeLayout(text, maxWidth, exactly);
     SpannableStringBuilder textWithExtraEnd = new SpannableStringBuilder(text);
-    textWithExtraEnd.append(COLLAPSE_NORMAL);
     if (mCollapseSpan != null) {
+      textWithExtraEnd.append(COLLAPSE_NORMAL);
       textWithExtraEnd.setSpan(mCollapseSpan, textWithExtraEnd.length() - 1,
           textWithExtraEnd.length(), Spanned.SPAN_INCLUSIVE_EXCLUSIVE);
     }

--- a/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
+++ b/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
@@ -8,6 +8,7 @@ import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
+import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.StaticLayout;
@@ -15,6 +16,7 @@ import android.text.StaticLayoutBuilderCompat;
 import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.style.ReplacementSpan;
+import android.text.util.Linkify;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.View;
@@ -27,7 +29,6 @@ public class ReadMoreTextView extends FastTextView {
   protected StaticLayout mAllTextLayout;
   protected StaticLayout mWithEllipsisLayout;
   protected ReplacementSpan mCollapseSpan = new EllipsisSpan(COLLAPSE_NORMAL);
-  protected boolean mCompressText;
 
   public ReadMoreTextView(Context context) {
     this(context, null);
@@ -116,24 +117,11 @@ public class ReadMoreTextView extends FastTextView {
   @NonNull
   @Override
   protected StaticLayout makeLayout(CharSequence text, int maxWidth, boolean exactly) {
-    if (mCompressText) {
-      String[] strs = text.toString().split("\n");
-      StringBuilder builder = new StringBuilder();
-      int realCount = 0;
-      for (String str : strs) {
-        realCount++;
-        if (str.isEmpty()) continue;
-        builder.append(str);
-        builder.append("\n");
-      }
-      if (realCount > 2) {
-        builder.append("\n"); // extra line to fix ellipse symbol display
-      }
-      mWithEllipsisLayout = super.makeLayout(builder.toString(), maxWidth, exactly);
-    } else {
-      mWithEllipsisLayout = super.makeLayout(text, maxWidth, exactly);
-    }
+    mWithEllipsisLayout = super.makeLayout(text, maxWidth, exactly);
     SpannableStringBuilder textWithExtraEnd = new SpannableStringBuilder(text);
+    if (mLinkifyMask > 0) {
+      Linkify.addLinks(textWithExtraEnd, mLinkifyMask);
+    }
     if (mCollapseSpan != null) {
       textWithExtraEnd.append(COLLAPSE_NORMAL);
       textWithExtraEnd.setSpan(mCollapseSpan, textWithExtraEnd.length() - 1,
@@ -203,10 +191,6 @@ public class ReadMoreTextView extends FastTextView {
 
   public boolean isShowAll() {
     return mIsShowAll;
-  }
-
-  public void compressText(boolean enable) {
-    mCompressText = enable;
   }
 
   public static class EllipsisSpan extends ReplacementSpan implements ClickableSpanUtil.Clickable {

--- a/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
+++ b/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
@@ -27,6 +27,7 @@ public class ReadMoreTextView extends FastTextView {
   protected StaticLayout mAllTextLayout;
   protected StaticLayout mWithEllipsisLayout;
   protected ReplacementSpan mCollapseSpan = new EllipsisSpan(COLLAPSE_NORMAL);
+  protected boolean mCompressText;
 
   public ReadMoreTextView(Context context) {
     this(context, null);
@@ -115,7 +116,7 @@ public class ReadMoreTextView extends FastTextView {
   @NonNull
   @Override
   protected StaticLayout makeLayout(CharSequence text, int maxWidth, boolean exactly) {
-    if (mAttrsHelper.mMaxLines < Integer.MAX_VALUE) {
+    if (mCompressText) {
       String[] strs = text.toString().split("\n");
       StringBuilder builder = new StringBuilder();
       for (String str : strs) {
@@ -123,6 +124,7 @@ public class ReadMoreTextView extends FastTextView {
         builder.append(str);
         builder.append("\n");
       }
+      builder.append("\n"); // extra line to fix ellipse symbol display
       mWithEllipsisLayout = super.makeLayout(builder.toString(), maxWidth, exactly);
     } else {
       mWithEllipsisLayout = super.makeLayout(text, maxWidth, exactly);
@@ -197,6 +199,10 @@ public class ReadMoreTextView extends FastTextView {
 
   public boolean isShowAll() {
     return mIsShowAll;
+  }
+
+  public void compressText(boolean enable) {
+    mCompressText = enable;
   }
 
   public static class EllipsisSpan extends ReplacementSpan implements ClickableSpanUtil.Clickable {

--- a/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
+++ b/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
@@ -115,7 +115,18 @@ public class ReadMoreTextView extends FastTextView {
   @NonNull
   @Override
   protected StaticLayout makeLayout(CharSequence text, int maxWidth, boolean exactly) {
-    mWithEllipsisLayout = super.makeLayout(text, maxWidth, exactly);
+    if (mAttrsHelper.mMaxLines < Integer.MAX_VALUE) {
+      String[] strs = text.toString().split("\n");
+      StringBuilder builder = new StringBuilder();
+      for (String str : strs) {
+        if (str.isEmpty()) continue;
+        builder.append(str);
+        builder.append("\n");
+      }
+      mWithEllipsisLayout = super.makeLayout(builder.toString(), maxWidth, exactly);
+    } else {
+      mWithEllipsisLayout = super.makeLayout(text, maxWidth, exactly);
+    }
     SpannableStringBuilder textWithExtraEnd = new SpannableStringBuilder(text);
     if (mCollapseSpan != null) {
       textWithExtraEnd.append(COLLAPSE_NORMAL);

--- a/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
+++ b/widget.FastTextView/src/main/java/com/lsjwzh/widget/text/ReadMoreTextView.java
@@ -119,12 +119,16 @@ public class ReadMoreTextView extends FastTextView {
     if (mCompressText) {
       String[] strs = text.toString().split("\n");
       StringBuilder builder = new StringBuilder();
+      int realCount = 0;
       for (String str : strs) {
+        realCount++;
         if (str.isEmpty()) continue;
         builder.append(str);
         builder.append("\n");
       }
-      builder.append("\n"); // extra line to fix ellipse symbol display
+      if (realCount > 2) {
+        builder.append("\n"); // extra line to fix ellipse symbol display
+      }
       mWithEllipsisLayout = super.makeLayout(builder.toString(), maxWidth, exactly);
     } else {
       mWithEllipsisLayout = super.makeLayout(text, maxWidth, exactly);


### PR DESCRIPTION
有些情况下展开之后不需要折叠回，目前即使setCustomCollapseSpan(null)还是会显示COLLAPSE_NORMAL符号，所以这里做了处理，使其能更自由的应对这种情况。